### PR TITLE
Update card styles for 3, 2 and single columns depending on view port

### DIFF
--- a/src/KenticoKontentBlog/Views/Shared/_ArticleList.cshtml
+++ b/src/KenticoKontentBlog/Views/Shared/_ArticleList.cshtml
@@ -8,10 +8,9 @@
     <div class="row">
         @foreach (var article in Model.Articles)
         {
-            <div class="col-sm-4">
+            <div class="col-12 col-lg-6 col-xl-4 mb-2">
                 <div class="card mx-1 my-1">
-                    <div class="card-header-image" style="background-image: url('@article.Image?w=400');">
-                    </div>
+                    <div class="card-header-image" style="background-image: url('@article.Image?w=700');"></div>
                     <div class="card-body">
                         <h5 class="card-title">
                             <a asp-controller="Article" asp-action="Index" asp-route-articleStub="@article.CodeName">@article.Title</a>
@@ -33,7 +32,6 @@
             </div>
         }
     </div>
-
     <div class="clearfix text-center mt-4">
         <a class="btn btn-primary" asp-controller="Article" asp-action="List" asp-route-category="All">All Articles &rarr;</a>
     </div>


### PR DESCRIPTION
closes #54 

Shows cards in 3 columns on large displays, 2 columns on medium displays and a single column on small devices.  Adds a bottom margin to cards.